### PR TITLE
Fix for issue " Results differ from python colormath package #6 "

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,5 @@ example/make_rgb_red
 /example/test/build/cmake/output
 /example/test/build/cmake/CMakeFiles
 /example/test/build/msvc/2017/out
+
+/.idea

--- a/src/color/generic/operation/distance/ciede2000.hpp
+++ b/src/color/generic/operation/distance/ciede2000.hpp
@@ -111,7 +111,6 @@
 
               scalar_type R_C =  2*sqrt( pow(C_p_a,7)/( pow(C_p_a,7) + pow(25,7) ) );
 
-              // fix conversion from deg to rad, not the other way round
               scalar_type R_T =  - R_C * sin( ( 2 * delta_theta) * constant_type::deg2rad() );
 
               scalar_type K_L = 1;
@@ -125,19 +124,9 @@
 
               scalar_type delta_E_main = sqrt( this_type::square( delta_E_1 ) + this_type::square( delta_E_2 ) + this_type::square( delta_E_3 ) + delta_E_4 );
 
-//              std::cout << "TEEST" << std::endl;
-//
-//              std::cout << "delta_E_1: " << delta_E_1 << std::endl;
-//              std::cout << "delta_E_2: " << delta_E_2 << std::endl;
-//              std::cout << "delta_E_3: " << delta_E_3 << std::endl;
-//              std::cout << "delta_E_4: " << delta_E_4 << std::endl;
-//              std::cout << "R_T: " << R_T << std::endl;
-//              std::cout << "R_C: " << R_C << std::endl;
-//              std::cout << "H_a_p: " << H_a_p << std::endl;
-//              std::cout << "delta_theta: " << delta_theta << std::endl;
-
               return delta_E_main;
-             }
+
+              }
          };
 
 

--- a/src/color/generic/operation/distance/ciede2000.hpp
+++ b/src/color/generic/operation/distance/ciede2000.hpp
@@ -110,7 +110,9 @@
               scalar_type delta_theta = 30 * exp( - this_type::square( ( H_a_p - 275)/25 ) );
 
               scalar_type R_C =  2*sqrt( pow(C_p_a,7)/( pow(C_p_a,7) + pow(25,7) ) );
-              scalar_type R_T =  - R_C * sin( ( 2 * delta_theta) * constant_type::rad2deg() );
+//              scalar_type R_T =  - R_C * sin( ( 2 * delta_theta) * constant_type::rad2deg() );
+              scalar_type R_T =  - R_C * sin( ( 2 * delta_theta));
+
 
               scalar_type K_L = 1;
               scalar_type K_C = 1;

--- a/src/color/generic/operation/distance/ciede2000.hpp
+++ b/src/color/generic/operation/distance/ciede2000.hpp
@@ -129,6 +129,7 @@
               std::cout << "delta_E_2: " << delta_E_2 << std::endl;
               std::cout << "delta_E_3: " << delta_E_3 << std::endl;
               std::cout << "delta_E_4: " << delta_E_4 << std::endl;
+              std::cout << "R_T: " << R_T << std::endl;
 
               return delta_E_main;
              }

--- a/src/color/generic/operation/distance/ciede2000.hpp
+++ b/src/color/generic/operation/distance/ciede2000.hpp
@@ -130,6 +130,7 @@
               std::cout << "delta_E_3: " << delta_E_3 << std::endl;
               std::cout << "delta_E_4: " << delta_E_4 << std::endl;
               std::cout << "R_T: " << R_T << std::endl;
+              std::cout << "R_C: " << R_C << std::endl;
 
               return delta_E_main;
              }

--- a/src/color/generic/operation/distance/ciede2000.hpp
+++ b/src/color/generic/operation/distance/ciede2000.hpp
@@ -110,8 +110,8 @@
               scalar_type delta_theta = 30 * exp( - this_type::square( ( H_a_p - 275)/25 ) );
 
               scalar_type R_C =  2*sqrt( pow(C_p_a,7)/( pow(C_p_a,7) + pow(25,7) ) );
-//              scalar_type R_T =  - R_C * sin( ( 2 * delta_theta) * constant_type::rad2deg() );
-              scalar_type R_T =  - R_C * sin( ( 2 * delta_theta));
+              scalar_type R_T =  - R_C * sin( ( 2 * delta_theta) * constant_type::deg2rad() );
+//              scalar_type R_T =  - R_C * sin( ( 2 * delta_theta));
 
 
               scalar_type K_L = 1;

--- a/src/color/generic/operation/distance/ciede2000.hpp
+++ b/src/color/generic/operation/distance/ciede2000.hpp
@@ -125,6 +125,11 @@
 
               std::cout << "TEEST" << std::endl;
 
+              std::cout << "delta_E_1: " << delta_E_1 << std::endl;
+              std::cout << "delta_E_2: " << delta_E_2 << std::endl;
+              std::cout << "delta_E_3: " << delta_E_3 << std::endl;
+              std::cout << "delta_E_4: " << delta_E_4 << std::endl;
+
               return delta_E_main;
              }
          };

--- a/src/color/generic/operation/distance/ciede2000.hpp
+++ b/src/color/generic/operation/distance/ciede2000.hpp
@@ -132,6 +132,7 @@
               std::cout << "R_T: " << R_T << std::endl;
               std::cout << "R_C: " << R_C << std::endl;
               std::cout << "H_a_p: " << H_a_p << std::endl;
+              std::cout << "delta_theta: " << delta_theta << std::endl;
 
               return delta_E_main;
              }

--- a/src/color/generic/operation/distance/ciede2000.hpp
+++ b/src/color/generic/operation/distance/ciede2000.hpp
@@ -123,6 +123,8 @@
 
               scalar_type delta_E_main = sqrt( this_type::square( delta_E_1 ) + this_type::square( delta_E_2 ) + this_type::square( delta_E_3 ) + delta_E_4 );
 
+              std::cout << "TEEST" << std::endl;
+
               return delta_E_main;
              }
          };

--- a/src/color/generic/operation/distance/ciede2000.hpp
+++ b/src/color/generic/operation/distance/ciede2000.hpp
@@ -110,9 +110,9 @@
               scalar_type delta_theta = 30 * exp( - this_type::square( ( H_a_p - 275)/25 ) );
 
               scalar_type R_C =  2*sqrt( pow(C_p_a,7)/( pow(C_p_a,7) + pow(25,7) ) );
-              scalar_type R_T =  - R_C * sin( ( 2 * delta_theta) * constant_type::deg2rad() );
-//              scalar_type R_T =  - R_C * sin( ( 2 * delta_theta));
 
+              // fix conversion from deg to rad, not the other way round
+              scalar_type R_T =  - R_C * sin( ( 2 * delta_theta) * constant_type::deg2rad() );
 
               scalar_type K_L = 1;
               scalar_type K_C = 1;
@@ -125,16 +125,16 @@
 
               scalar_type delta_E_main = sqrt( this_type::square( delta_E_1 ) + this_type::square( delta_E_2 ) + this_type::square( delta_E_3 ) + delta_E_4 );
 
-              std::cout << "TEEST" << std::endl;
-
-              std::cout << "delta_E_1: " << delta_E_1 << std::endl;
-              std::cout << "delta_E_2: " << delta_E_2 << std::endl;
-              std::cout << "delta_E_3: " << delta_E_3 << std::endl;
-              std::cout << "delta_E_4: " << delta_E_4 << std::endl;
-              std::cout << "R_T: " << R_T << std::endl;
-              std::cout << "R_C: " << R_C << std::endl;
-              std::cout << "H_a_p: " << H_a_p << std::endl;
-              std::cout << "delta_theta: " << delta_theta << std::endl;
+//              std::cout << "TEEST" << std::endl;
+//
+//              std::cout << "delta_E_1: " << delta_E_1 << std::endl;
+//              std::cout << "delta_E_2: " << delta_E_2 << std::endl;
+//              std::cout << "delta_E_3: " << delta_E_3 << std::endl;
+//              std::cout << "delta_E_4: " << delta_E_4 << std::endl;
+//              std::cout << "R_T: " << R_T << std::endl;
+//              std::cout << "R_C: " << R_C << std::endl;
+//              std::cout << "H_a_p: " << H_a_p << std::endl;
+//              std::cout << "delta_theta: " << delta_theta << std::endl;
 
               return delta_E_main;
              }

--- a/src/color/generic/operation/distance/ciede2000.hpp
+++ b/src/color/generic/operation/distance/ciede2000.hpp
@@ -131,6 +131,7 @@
               std::cout << "delta_E_4: " << delta_E_4 << std::endl;
               std::cout << "R_T: " << R_T << std::endl;
               std::cout << "R_C: " << R_C << std::endl;
+              std::cout << "H_a_p: " << H_a_p << std::endl;
 
               return delta_E_main;
              }


### PR DESCRIPTION
After some debugging, the problem turned out to be a wrong conversion. You converted a value from rad to deg instead the other way round. This does not make sense, as the sin() function takes values in radians. After the fix is applied, the values match with python-colormath.